### PR TITLE
Add/docker nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,18 @@ services:
       - es_data:/usr/share/elasticsearch/data
       - ./esconfig:/usr/share/elasticsearch/config
 
+  http-portal:
+    image: steveltn/https-portal:1
+    ports:
+      - '80:80'
+      - '443:443'
+    links:
+      - app:app
+    environment:
+      DOMAINS: 'test.crowi-plus.org -> http://app:3000'
+      STAGE: 'production'
+      FORCE_RENEW: 'true'
+
 volumes:
   crowi_data:
   mongo_configdb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,9 +61,9 @@ services:
     links:
       - app:app
     environment:
-      DOMAINS: 'test.crowi-plus.org -> http://app:3000'
-      STAGE: 'production'
-      FORCE_RENEW: 'true'
+      DOMAINS: 'crowi-plus.example.com -> http://app:3000'
+      # STAGE: 'production'
+      # FORCE_RENEW: 'true'
 
 volumes:
   crowi_data:

--- a/examples/http-proxy/docker-compose.yml
+++ b/examples/http-proxy/docker-compose.yml
@@ -1,6 +1,23 @@
 version: '3'
 
 services:
+  # a fully automated HTTPS server powered by Nginx, Let's Encrypt
+  # see https://github.com/SteveLTN/https-portal
+  https-portal:
+    image: steveltn/https-portal:1
+    ports:
+      - '80:80'
+      - '443:443'
+    links:
+      - app:app
+    environment:
+      DOMAINS: 'example.com -> http://app:3000'
+      STAGE: 'production'
+      FORCE_RENEW: 'true'
+      WEBSOCKET: 'true'
+    volumes:
+      - https-portal_data:/var/lib/https-portal
+
   app:
     build:
       context: .
@@ -54,6 +71,7 @@ services:
       - ./esconfig:/usr/share/elasticsearch/config
 
 volumes:
+  https-portal_data:
   crowi_data:
   mongo_configdb:
   mongo_db:


### PR DESCRIPTION
Let's Encryptで証明書を取得してくれるnginxのプロキシコンテナを追加しました
Added [http-portal container](https://github.com/SteveLTN/https-portal) that works as a reverse proxy with Let's Encrypt.

DOMAINの箇所を変更することで、nginxのvhost設定の値が書き換わります。
デフォルトの状態では実際の証明書は取得しません。STAGEのコメントを外してproductionの値を有効にすることで、Let's Encryptのスクリプトが走ります。
Changing the domain name at "DOMAINS" option in the environment directive, You can set your own FQDN.
By default, STAGE option is set as 'develop'. Setting it as production and uncomment the directive, it will try to get an actual certificate on Let's Encrypt.
For more details, please read the [documentation](https://github.com/SteveLTN/https-portal)