### PR TITLE
Use ES plugin configuration file instead of Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,10 @@ docker compose stop
 
 # remove current container and images
 docker compose rm app
-docker rmi weseek/growi:7
 
-# rebuild app container image
+# update latest container image
 git pull
-docker compose build
+docker compose pull
 
 # start
 docker compose up

--- a/docker-compose.es7.yml
+++ b/docker-compose.es7.yml
@@ -44,9 +44,7 @@ services:
       retries: 6
 
   elasticsearch:
-    build:
-      context: ./elasticsearch/v7
-      dockerfile: ./Dockerfile
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory
@@ -59,6 +57,7 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
       - ./elasticsearch/v7/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      - ./elasticsearch/v7/config/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 10s

--- a/docker-compose.v70x-es7.yml
+++ b/docker-compose.v70x-es7.yml
@@ -44,9 +44,7 @@ services:
       retries: 6
 
   elasticsearch:
-    build:
-      context: ./elasticsearch/v7
-      dockerfile: ./Dockerfile
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory
@@ -59,6 +57,7 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
       - ./elasticsearch/v7/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      - ./elasticsearch/v7/config/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 10s

--- a/docker-compose.v70x.yml
+++ b/docker-compose.v70x.yml
@@ -44,9 +44,7 @@ services:
       retries: 6
 
   elasticsearch:
-    build:
-      context: ./elasticsearch/v8
-      dockerfile: ./Dockerfile
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory
@@ -59,6 +57,7 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
       - ./elasticsearch/v8/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      - ./elasticsearch/v8/config/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,7 @@ services:
       retries: 6
 
   elasticsearch:
-    build:
-      context: ./elasticsearch/v8
-      dockerfile: ./Dockerfile
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory
@@ -59,6 +57,7 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
       - ./elasticsearch/v8/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      - ./elasticsearch/v8/config/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 10s

--- a/elasticsearch/v7/Dockerfile
+++ b/elasticsearch/v7/Dockerfile
@@ -1,6 +1,0 @@
-ARG version=7.17.1
-FROM docker.elastic.co/elasticsearch/elasticsearch:${version}
-LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
-
-RUN bin/elasticsearch-plugin install analysis-kuromoji
-RUN bin/elasticsearch-plugin install analysis-icu

--- a/elasticsearch/v7/config/elasticsearch-plugins.yml
+++ b/elasticsearch/v7/config/elasticsearch-plugins.yml
@@ -1,0 +1,3 @@
+plugins:
+  - id: analysis-kuromoji
+  - id: analysis-icu

--- a/elasticsearch/v8/Dockerfile
+++ b/elasticsearch/v8/Dockerfile
@@ -1,6 +1,0 @@
-ARG version=8.7.0
-FROM docker.elastic.co/elasticsearch/elasticsearch:${version}
-LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
-
-RUN bin/elasticsearch-plugin install analysis-kuromoji
-RUN bin/elasticsearch-plugin install analysis-icu

--- a/elasticsearch/v8/config/elasticsearch-plugins.yml
+++ b/elasticsearch/v8/config/elasticsearch-plugins.yml
@@ -1,0 +1,3 @@
+plugins:
+  - id: analysis-kuromoji
+  - id: analysis-icu


### PR DESCRIPTION
Elasticsearch official Docker images have [plugin configuration](https://www.elastic.co/guide/en/elasticsearch/plugins/8.17/manage-plugins-using-configuration-file.html).
So this PR use it. Now no need to manage and build ES images.

<img width="638" alt="Screenshot 2025-01-15 23 17 08" src="https://github.com/user-attachments/assets/cf16dfb9-cada-45a5-b782-2366b3b301c5" />
