### PR TITLE
support: Replace Elasticsearch Dockerfiles with official images and elasticsearch-plugins.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,11 +48,9 @@ services:
       retries: 6
 
   elasticsearch:
-    build:
-      context: ./elasticsearch/v9
-      # For Elasticsearch 8.x
-      # context: ./elasticsearch/v8
-      dockerfile: ./Dockerfile
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.3
+    # For Elasticsearch 8.x
+    # image: docker.elastic.co/elasticsearch/elasticsearch:8.18.2
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory
@@ -65,8 +63,10 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
       - ./elasticsearch/v9/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      - ./elasticsearch/v9/config/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
       # For Elasticsearch 8.x
       #- ./elasticsearch/v8/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      #- ./elasticsearch/v8/config/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,9 +48,9 @@ services:
       retries: 6
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.3
     # For Elasticsearch 8.x
-    # image: docker.elastic.co/elasticsearch/elasticsearch:8.18.2
+    # image: docker.elastic.co/elasticsearch/elasticsearch:8.19.14
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory

--- a/elasticsearch/v8/Dockerfile
+++ b/elasticsearch/v8/Dockerfile
@@ -1,6 +1,0 @@
-ARG version=8.18.2
-FROM docker.elastic.co/elasticsearch/elasticsearch:${version}
-LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
-
-RUN bin/elasticsearch-plugin install analysis-kuromoji
-RUN bin/elasticsearch-plugin install analysis-icu

--- a/elasticsearch/v8/config/elasticsearch-plugins.yml
+++ b/elasticsearch/v8/config/elasticsearch-plugins.yml
@@ -1,0 +1,3 @@
+plugins:
+  - id: analysis-kuromoji
+  - id: analysis-icu

--- a/elasticsearch/v9/Dockerfile
+++ b/elasticsearch/v9/Dockerfile
@@ -1,6 +1,0 @@
-ARG version=9.0.3
-FROM docker.elastic.co/elasticsearch/elasticsearch:${version}
-LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
-
-RUN bin/elasticsearch-plugin install analysis-kuromoji
-RUN bin/elasticsearch-plugin install analysis-icu

--- a/elasticsearch/v9/config/elasticsearch-plugins.yml
+++ b/elasticsearch/v9/config/elasticsearch-plugins.yml
@@ -1,0 +1,3 @@
+plugins:
+  - id: analysis-kuromoji
+  - id: analysis-icu


### PR DESCRIPTION
## Summary

- Remove custom Dockerfiles for Elasticsearch v8 and v9 that installed `analysis-kuromoji` and `analysis-icu` via `RUN` commands
- Add `elasticsearch-plugins.yml` for v8 and v9; Elasticsearch 8+ auto-installs declared plugins on startup — no custom image needed
- Update `docker-compose.yml` to use the official Elasticsearch images directly and add volume mounts for `elasticsearch-plugins.yml`

## Background

This applies the same pattern proposed in #78 (which covered v7/v8) to v9, and supersedes it.

Closes #78

## Test plan

- [ ] `docker compose up` starts Elasticsearch 9 successfully
- [ ] kuromoji and icu analysis plugins are available after startup
- [ ] GROWI search works correctly with the official image

🤖 Generated with [Claude Code](https://claude.com/claude-code)